### PR TITLE
Update Config.php

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -141,7 +141,7 @@ class Config extends AbstractHelper
     {
         $events = $this->scopeConfig->getValue(self::XML_PATH_EVENTS_ALL);
 
-        return is_array($events) ? $events : explode(',', $events);
+        return is_array($events) ? $events : explode(',', (string) $events);
     }
 
     /**
@@ -153,7 +153,7 @@ class Config extends AbstractHelper
     {
         $events = $this->scopeConfig->getValue(self::XML_PATH_EVENTS_PARTIAL);
 
-        return is_array($events) ? $events : explode(',', $events);
+        return is_array($events) ? $events : explode(',', (string) $events);
     }
 
     /**


### PR DESCRIPTION
Resolves issue:
Deprecated Functionality: explode(): Passing null to parameter #2 ($string) of type string is deprecated in /var/www/html/vendor/webscale-networks/magento-varnish-api/Helper/Config.php on line 156