### PR TITLE
Fixed `tagsPattern` usage in Helper/Config.php

### DIFF
--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -173,16 +173,18 @@ class Config extends AbstractHelper
     {
         $params = [
             'json' => [
-                'type' => 'invalidate-cache',
-                'target' => '/v2/applications/' . $this->getApplicationId(),
+                'type'       => 'invalidate-cache',
+                'target'     => '/v2/applications/' . $this->getApplicationId(),
                 'parameters' => []
             ],
         ];
 
-        if(!empty($purge['tags'])) {
+        if (!empty($purge['tagsPattern'])) {
+            $params['json']['parameters']['tags'] = $purge['tagsPattern'];
+        } elseif (!empty($purge['tags'])) {
             $params['json']['parameters']['tags'] = $purge['tags'];
         }
-        if(!empty($purge['urls'])) {
+        if (!empty($purge['urls'])) {
             $params['json']['parameters']['urls'] = $purge['urls'];
         }
 


### PR DESCRIPTION
Latest changes in v1.2.4 breaks purge requests.
Some parts of code still use `tagsPattern` that was removed here. As a result requests go with empty `parameters` array.

Reverted usage of `tagsPattern`.