### PR TITLE
Move error information from message to context.

### DIFF
--- a/Model/PurgeCache.php
+++ b/Model/PurgeCache.php
@@ -75,9 +75,10 @@ class PurgeCache
                 : '.*';
 
             if (!in_array($response->getStatusCode(), [200, 201])) {
+                $error = $response->getReasonPhrase();
                 $this->logger->warning(
-                    'Error executing purge: ' . $tagsPattern . ', Error: ' . $response->getReasonPhrase(),
-                    compact('servers', 'tagsPattern')
+                    'Error executing purge',
+                    compact('servers', 'tagsPattern', 'params', 'error')
                 );
                 return false;
             }


### PR DESCRIPTION
It is correct implementation that will help customers that use Sentry.io or similar service. They will see only one error with different context instead of new error each time.